### PR TITLE
FastBaumWelch loss as PyTorch autograd function

### DIFF
--- a/i6_native_ops/fbw/__init__.py
+++ b/i6_native_ops/fbw/__init__.py
@@ -52,7 +52,7 @@ def fbw_loss(
     """ 
     Computes negative log likelihood of an emission model given an HMM finite state automaton.
     The corresponding gradient with respect to the emission model is automatically backpropagated.
-    :param log_probs: log probabilities of emission model as a (T, B, F)
+    :param log_probs: log probabilities of emission model as a [B, T, F] tensor
     :param fsa: weighted finite state automaton as a tuple consisting of:
         * number of states
         * a (4, E) tensor of integers specifying where each column consists of
@@ -63,6 +63,6 @@ def fbw_loss(
     :param seq_lens: (B,) tensor consisting of the sequence lengths
     :return: (B,) tensor of loss values
     """
-    neg_log_probs = log_probs.neg()
+    neg_log_probs = log_probs.neg().transpose(0, 1).contiguous() # [T, B, F]
     loss = FastBaumWelchLoss.apply(neg_log_probs, fsa, seq_lens)
     return loss

--- a/i6_native_ops/fbw/__init__.py
+++ b/i6_native_ops/fbw/__init__.py
@@ -1,2 +1,65 @@
 import torch  # needed to find pytorch specific libs
-from .fbw_core import fbw
+from pkg_resources import get_distribution
+
+try:
+    # Package is installed, so ops are already compiled
+    __version__ = get_distribution('i6_native_ops').version
+    from . import fbw_core as core
+except Exception as e:
+    # otherwise try to build locally
+    from torch.utils.cpp_extension import load
+    base_path = os.path.dirname(__file__)
+    core = load(
+        name="fbw_core",
+        sources=[
+            os.path.join(base_path, "fbw_torch.cpp"),
+            os.path.join(base_path, "fbw_op.cu"),
+        ],
+        extra_include_paths=[
+            base_path,
+            os.path.join(base_path, "..", "common")
+        ],
+	)
+
+
+class FastBaumWelchLoss(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, am_scores, fsa, seq_lens):
+        num_states, edge_tensor, weight_tensor, start_end_states = fsa
+
+        grad, loss = fbw(
+            am_scores, edge_tensor, weight_tensor,
+            start_end_states, seq_lens, int(num_states),
+            nativeops.DebugOptions()
+        )
+        ctx.save_for_backward(grad)
+        return loss
+    
+    @staticmethod
+    def backward(ctx, grad_loss):
+        # negative log prob -> prob
+        grad = ctx.saved_tensors[0].neg().exp()
+        return grad, None, None
+
+
+def fbw_loss(
+    neg_log_probs: torch.FloatTensor,
+    fsa: Tuple[int, torch.IntTensor, torch.FloatTensor, torch.IntTensor],
+    seq_lens: torch.IntTensor
+) -> Tuple[torch.IntTensor, torch.FloatTensor]:
+    """ 
+    Computes negative log likelihood of an emission model given an HMM finite state automaton.
+    The corresponding gradient with respect to the emission model is automatically backpropagated.
+    :param log_probs: negative log probabilities of emission model as a (T, B, F)
+    :param fsa: weighted finite state automaton as a tuple consisting of:
+        * number of states
+        * a (4, E) tensor of integers specifying where each column consists of
+            origin state, target state, emission idx and the index of the sequence
+        * a (E,) tensor of floats holding the weight of each edge
+        * a (2, B) tensor of starting and ending states for each automaton in the batch where
+            the first row are starting states and the second the corresponding ending states
+    :param seq_lens: (B,) tensor consisting of the sequence lengths
+    :return: (B,) tensor of loss values
+    """
+    loss = FastBaumWelchLoss.apply(neg_log_probs, fsa, seq_lens)
+    return loss

--- a/i6_native_ops/fbw/__init__.py
+++ b/i6_native_ops/fbw/__init__.py
@@ -1,5 +1,6 @@
 import torch  # needed to find pytorch specific libs
 from pkg_resources import get_distribution
+from typing import Tuple
 
 try:
     # Package is installed, so ops are already compiled
@@ -27,10 +28,10 @@ class FastBaumWelchLoss(torch.autograd.Function):
     def forward(ctx, am_scores, fsa, seq_lens):
         num_states, edge_tensor, weight_tensor, start_end_states = fsa
 
-        grad, loss = fbw(
+        grad, loss = core.fbw(
             am_scores, edge_tensor, weight_tensor,
             start_end_states, seq_lens, int(num_states),
-            nativeops.DebugOptions()
+            core.DebugOptions()
         )
         ctx.save_for_backward(grad)
         return loss
@@ -43,14 +44,14 @@ class FastBaumWelchLoss(torch.autograd.Function):
 
 
 def fbw_loss(
-    neg_log_probs: torch.FloatTensor,
+    log_probs: torch.FloatTensor,
     fsa: Tuple[int, torch.IntTensor, torch.FloatTensor, torch.IntTensor],
     seq_lens: torch.IntTensor
 ) -> Tuple[torch.IntTensor, torch.FloatTensor]:
     """ 
     Computes negative log likelihood of an emission model given an HMM finite state automaton.
     The corresponding gradient with respect to the emission model is automatically backpropagated.
-    :param log_probs: negative log probabilities of emission model as a (T, B, F)
+    :param log_probs: log probabilities of emission model as a (T, B, F)
     :param fsa: weighted finite state automaton as a tuple consisting of:
         * number of states
         * a (4, E) tensor of integers specifying where each column consists of
@@ -61,5 +62,6 @@ def fbw_loss(
     :param seq_lens: (B,) tensor consisting of the sequence lengths
     :return: (B,) tensor of loss values
     """
+    neg_log_probs = log_probs.neg()
     loss = FastBaumWelchLoss.apply(neg_log_probs, fsa, seq_lens)
     return loss

--- a/i6_native_ops/fbw/__init__.py
+++ b/i6_native_ops/fbw/__init__.py
@@ -48,7 +48,7 @@ def fbw_loss(
     log_probs: torch.FloatTensor,
     fsa: Tuple[int, torch.IntTensor, torch.FloatTensor, torch.IntTensor],
     seq_lens: torch.IntTensor
-) -> Tuple[torch.IntTensor, torch.FloatTensor]:
+) -> torch.FloatTensor:
     """ 
     Computes negative log likelihood of an emission model given an HMM finite state automaton.
     The corresponding gradient with respect to the emission model is automatically backpropagated.

--- a/i6_native_ops/fbw/__init__.py
+++ b/i6_native_ops/fbw/__init__.py
@@ -1,3 +1,4 @@
+import os
 import torch  # needed to find pytorch specific libs
 from pkg_resources import get_distribution
 from typing import Tuple

--- a/i6_native_ops/fbw/__init__.py
+++ b/i6_native_ops/fbw/__init__.py
@@ -19,7 +19,7 @@ except Exception as e:
             base_path,
             os.path.join(base_path, "..", "common")
         ],
-	)
+    )
 
 
 class FastBaumWelchLoss(torch.autograd.Function):

--- a/test/fbw.py
+++ b/test/fbw.py
@@ -1,0 +1,49 @@
+import unittest
+import torch
+
+from i6_native_ops.fbw import fbw_loss
+
+class TestFastBaumWelch(unittest.TestCase):
+
+    def test_grad(self):
+        log_probs = (
+            torch.tensor([
+                    [0.9, 0.1],
+                    [0.9, 0.1],
+                    [0.4, 0.6],
+                    [0.1, 0.9],
+                    [0.1, 0.9],
+                ], device="cuda", dtype=torch.float32,
+                requires_grad=True)
+            .unsqueeze(1)
+            .log()
+        )
+        edges = (
+            torch.tensor([
+                # from, to, emission_idx, sequence_idx
+                [0, 0, 0, 0], # loop from 0 to 0, emit label 0
+                [0, 1, 0, 0], # forward from 0 to 1, emit 0
+                [1, 1, 1, 0]], # loop from 1 to 1, emit 1
+                device="cuda", dtype=torch.int32)
+            .transpose(0, 1).contiguous()
+        )
+        weights = torch.tensor([1, 1, 1], device="cuda", dtype=torch.float32)
+        start_end_states = torch.tensor([[0], [1]], dtype=torch.int32, device="cuda")
+        seq_lens = torch.tensor([5], dtype=torch.int32, device="cuda")
+
+        fsa = (2, edges, weights, start_end_states)
+
+        log_probs.retain_grad()
+        loss = fbw_loss(log_probs, fsa, seq_lens)
+        loss.sum().backward()
+        grad = log_probs.grad
+
+        self.assertTrue(
+            torch.isclose(
+                grad.sum(-1).neg(),
+                torch.full(log_probs.shape[:2], 1.0, device="cuda")
+            ).all()
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a FastBaumWelch loss as a `torch.autograd` function and a simple wrapper for it. This can be imported and used in training directly.
Additionally add autoload mechanism.
Add test case.