### PR TITLE
Add check for tensor element type in fbw + fast_viterbi op

### DIFF
--- a/i6_native_ops/common/returnn_definitions.h
+++ b/i6_native_ops/common/returnn_definitions.h
@@ -90,14 +90,22 @@ static void _cudaHandleError(cublasStatus_t status, const char* file, int line) 
 #define HANDLE_ERROR(status) (_cudaHandleError(status, __FILE__, __LINE__))
 #define HANDLE_LAST_ERROR() (HANDLE_ERROR(cudaGetLastError()))
 
-long Ndarray_get_n_total_elements(Ndarray& a) {
+#define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_TYPE(x, type) TORCH_CHECK(x.dtype() == type, "Expected " #x " to contain elements of type ", type, ", but got type ", x.dtype())
+#define CHECK_INPUT(x, type) \
+    CHECK_CUDA(x);           \
+    CHECK_CONTIGUOUS(x);     \
+    CHECK_TYPE(x, type)
+
+inline long Ndarray_get_n_total_elements(Ndarray& a) {
     long c = 1;
     for (long i = 0; i < Ndarray_NDIM(a); ++i)
         c *= Ndarray_DIMS(a)[i];
     return c;
 }
 
-void _Ndarray_set_zero(Ndarray& a) {
+inline void _Ndarray_set_zero(Ndarray& a) {
     long size = Ndarray_get_n_total_elements(a) * Ndarray_dtype_size(a);
     Ndarray_memset(Ndarray_DEV_DATA(a), 0, size);
 }
@@ -120,55 +128,55 @@ DEV_FUNC HOST_FUNC const char* _format_for_type(const T&) {
     assert(0);
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const char&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const char&) {
     return "%c";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned char&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned char&) {
     return "%u";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const short&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const short&) {
     return "%hi";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned short&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned short&) {
     return "%hu";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const int&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const int&) {
     return "%i";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned int&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned int&) {
     return "%u";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const long&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const long&) {
     return "%li";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned long&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned long&) {
     return "%lu";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const long long&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const long long&) {
     return "%lli";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned long long&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const unsigned long long&) {
     return "%llu";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const float&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const float&) {
     return "%f";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const double&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const double&) {
     return "%f";
 }
 template<>
-DEV_FUNC HOST_FUNC const char* _format_for_type(const long double&) {
+inline DEV_FUNC HOST_FUNC const char* _format_for_type(const long double&) {
     return "%Lf";
 }
 

--- a/i6_native_ops/fast_viterbi/binding.cpp
+++ b/i6_native_ops/fast_viterbi/binding.cpp
@@ -2,26 +2,22 @@
 
 #include <torch/extension.h>
 
+#include "../common/returnn_definitions.h"
+
 namespace py = pybind11;
 
 std::vector<torch::Tensor> fast_viterbi_cuda(torch::Tensor& am_scores, torch::Tensor& edges,
                                              torch::Tensor& weights, torch::Tensor& start_end_states,
                                              torch::Tensor& seq_lens, unsigned n_states);
 
-#define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
-#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
-#define CHECK_INPUT(x) \
-    CHECK_CUDA(x);     \
-    CHECK_CONTIGUOUS(x)
-
 std::vector<torch::Tensor> fast_viterbi(torch::Tensor& am_scores, torch::Tensor& edges,
                                         torch::Tensor& weights, torch::Tensor& start_end_states,
                                         torch::Tensor& seq_lens, unsigned num_states) {
-    CHECK_INPUT(am_scores);
-    CHECK_INPUT(edges);
-    CHECK_INPUT(weights);
-    CHECK_INPUT(start_end_states);
-    CHECK_INPUT(seq_lens);
+    CHECK_INPUT(am_scores, torch::kFloat32);
+    CHECK_INPUT(edges, torch::kInt32);
+    CHECK_INPUT(weights, torch::kFloat32);
+    CHECK_INPUT(start_end_states, torch::kInt32);
+    CHECK_INPUT(seq_lens, torch::kInt32);
 
     auto outputs = fast_viterbi_cuda(am_scores, edges, weights, start_end_states, seq_lens, num_states);
 

--- a/i6_native_ops/fbw/fbw_torch.cpp
+++ b/i6_native_ops/fbw/fbw_torch.cpp
@@ -2,7 +2,8 @@
 
 #include <torch/extension.h>
 
-#include <DebugOptions.h>
+#include "../common/returnn_definitions.h"
+#include "DebugOptions.h"
 
 namespace py = pybind11;
 
@@ -10,14 +11,6 @@ std::vector<torch::Tensor> fbw_cuda(torch::Tensor& am_scores, torch::Tensor& edg
                                     torch::Tensor& weights, torch::Tensor& start_end_states,
                                     torch::Tensor& seq_lens, unsigned n_states,
                                     DebugOptions debug_options);
-
-#define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
-#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
-#define CHECK_TYPE(x, type) TORCH_CHECK(x.dtype() == type, "Expected " #x " to contain elements of type ", type, ", but got type ", x.dtype())
-#define CHECK_INPUT(x, type) \
-    CHECK_CUDA(x);           \
-    CHECK_CONTIGUOUS(x);     \
-    CHECK_TYPE(x, type)
 
 std::vector<torch::Tensor> fbw(torch::Tensor& am_scores, torch::Tensor& edges,
                                torch::Tensor& weights, torch::Tensor& start_end_states,

--- a/i6_native_ops/fbw/fbw_torch.cpp
+++ b/i6_native_ops/fbw/fbw_torch.cpp
@@ -13,19 +13,21 @@ std::vector<torch::Tensor> fbw_cuda(torch::Tensor& am_scores, torch::Tensor& edg
 
 #define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
-#define CHECK_INPUT(x) \
-    CHECK_CUDA(x);     \
-    CHECK_CONTIGUOUS(x)
+#define CHECK_TYPE(x, type) TORCH_CHECK(x.dtype() == type, "Expected " #x " to contain elements of type ", type, ", but got type ", x.dtype())
+#define CHECK_INPUT(x, type) \
+    CHECK_CUDA(x);           \
+    CHECK_CONTIGUOUS(x);     \
+    CHECK_TYPE(x, type)
 
 std::vector<torch::Tensor> fbw(torch::Tensor& am_scores, torch::Tensor& edges,
                                torch::Tensor& weights, torch::Tensor& start_end_states,
                                torch::Tensor& seq_lens, unsigned num_states,
                                DebugOptions debug_options = DebugOptions()) {
-    CHECK_INPUT(am_scores);
-    CHECK_INPUT(edges);
-    CHECK_INPUT(weights);
-    CHECK_INPUT(start_end_states);
-    CHECK_INPUT(seq_lens);
+    CHECK_INPUT(am_scores, torch::kFloat32);
+    CHECK_INPUT(edges, torch::kInt32);
+    CHECK_INPUT(weights, torch::kFloat32);
+    CHECK_INPUT(start_end_states, torch::kInt32);
+    CHECK_INPUT(seq_lens, torch::kInt32);
 
     auto outputs = fbw_cuda(am_scores, edges, weights, start_end_states, seq_lens, num_states,
                             debug_options);


### PR DESCRIPTION
The fbw cuda op assumes the tensors to have elements of specific types, but this wasn't actually checked.

E.g. if the `seq_lens`-tensor actually has `torch::kInt64` as element type, every second sequence would be read as having length 0.