### PR TITLE
Make loss scaling work with fbw_loss

### DIFF
--- a/i6_native_ops/fbw/__init__.py
+++ b/i6_native_ops/fbw/__init__.py
@@ -41,7 +41,8 @@ class FastBaumWelchLoss(torch.autograd.Function):
     def backward(ctx, grad_loss):
         # negative log prob -> prob
         grad = ctx.saved_tensors[0].neg().exp()
-        return grad, None, None
+        final_grad = grad_loss * grad
+        return final_grad, None, None
 
 
 def fbw_loss(

--- a/i6_native_ops/fbw/__init__.py
+++ b/i6_native_ops/fbw/__init__.py
@@ -66,4 +66,4 @@ def fbw_loss(
     """
     neg_log_probs = log_probs.neg().transpose(0, 1).contiguous() # [T, B, F]
     loss = FastBaumWelchLoss.apply(neg_log_probs, fsa, seq_lens)
-    return loss
+    return loss[0]


### PR DESCRIPTION
Previously, grad_loss, i.e. the derivative of "final loss" wrt "raw loss"(loss returned in forward), was ignored in fbw_loss backward function. This means the gradient is already determined during forward, multiplying/dividing the loss by any value will not affect the gradient. I suggest multiplying the original gradient by grad_loss to support scaling/normalization of the loss.

In order to make the loss compatible with previous training, I make fbw_loss only return a tensor of [B], which used to be [T, B](just [B] duplicated/broadcasted over T). The duplication was not a problem since the loss didn't affect gradient computation. Now, the duplicated loss will result in gradients that are too large by a factor of T if you simply sum the loss in train_step.

The changes are tested and work as expected.