### PR TITLE
Fix CUDA illegal memory access bug in monotonic_rnnt

### DIFF
--- a/i6_native_ops/monotonic_rnnt/include/gpu_rnnt_kernel.h
+++ b/i6_native_ops/monotonic_rnnt/include/gpu_rnnt_kernel.h
@@ -71,10 +71,10 @@ inline HOSTDEVICE int beta_s_max(const int t, const int S, const int *max_allowe
     return t == 0 ? 0 : (t < max_allowed_s[t - 1] ? t : max_allowed_s[t - 1]);
 }
 
-inline HOSTDEVICE int denom_idx(const int t, const int s, const int S) { return t * (S + 1) + s; }
+inline HOSTDEVICE int64_t denom_idx(const int t, const int s, const int S) { return t * (S + 1) + s; }
 
-inline HOSTDEVICE int act_idx(const int t, const int s, const int v, const int S, const int V) {
-    return (denom_idx(t, s, S)) * V + v;
+inline HOSTDEVICE int64_t act_idx(const int t, const int s, const int v, const int S, const int V) {
+    return denom_idx(t, s, S) * V + v;
 }
 
 template <typename dtype>

--- a/i6_native_ops/monotonic_rnnt/include/gpu_rnnt_kernel.h
+++ b/i6_native_ops/monotonic_rnnt/include/gpu_rnnt_kernel.h
@@ -244,7 +244,7 @@ __global__ void compute_grad_kernel(Tp *grads, const Tp *const acts, const Tp *c
                                     const int *const S_max, const int *const T_max, const int *const min_allowed_s,
                                     const int *const max_allowed_s, const int *const V, const int blank_) {
     int v = static_cast<int>(threadIdx.x);
-    int bts = static_cast<int>(blockIdx.x);  // b, t, s packed
+    int64_t bts = static_cast<int64_t>(blockIdx.x);  // b, t, s packed
 
     int b = 0;
     while (b < *B - 1 && denom_start_indices[b + 1] <= bts) {
@@ -259,7 +259,7 @@ __global__ void compute_grad_kernel(Tp *grads, const Tp *const acts, const Tp *c
     const int *min_allowed_s_b = min_allowed_s + b * *T_max;
     const int *max_allowed_s_b = max_allowed_s + b * *T_max;
 
-    int ts = bts - denom_start_indices[b];
+    int64_t ts = bts - denom_start_indices[b];
     int t = ts / (S_b + 1);
     int s = ts % (S_b + 1);
 


### PR DESCRIPTION
The size of the gradient tensor in monotonic RNN-T loss computation is essentially `B * T * (S+1) * V`. For larger vocabulary sizes and sequence lengths, this size can overflow the signed 32-bit integer limit. In the current implementation of the gradient CUDA kernel, the index for writing into the gradient tensor (`grads[bts * *V + v] = ...`) has a datatype of `int`, so such an overflow leads to a negative index and thus an illegal memory access error. Changing the datatype to `int64_t` fixes the issue.